### PR TITLE
handle errors & polish

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,7 @@
 /// assert_eq!(flat_tree::index(0, 2), 4);
 /// ```
 pub fn index(depth: u64, offset: u64) -> u64 {
-  return (offset << depth + 1) | ((1 << depth) - 1);
+  (offset << depth + 1) | ((1 << depth) - 1)
 }
 
 /// Returns the depth of a node.
@@ -41,16 +41,20 @@ pub fn index(depth: u64, offset: u64) -> u64 {
 pub fn depth(i: u64) -> u64 {
   let mut depth = 0;
   let mut i = i;
-  while i & 1 != 0 {
+  while is_odd(i) {
     i >>= 1;
     depth += 1;
   }
-  return depth;
+  depth
 }
 
 /// Returns the offset of a node with a depth.
 pub fn offset_with_depth(i: u64, depth: u64) -> u64 {
-  return i >> (depth + 1);
+  if is_even(i) {
+    i / 2
+  } else {
+    i >> (depth + 1)
+  }
 }
 
 /// Returns the offset of a node.
@@ -64,12 +68,12 @@ pub fn offset_with_depth(i: u64, depth: u64) -> u64 {
 /// assert_eq!(flat_tree::offset(4), 2);
 /// ```
 pub fn offset(i: u64) -> u64 {
-  return offset_with_depth(i, depth(i));
+  offset_with_depth(i, depth(i))
 }
 
 /// Returns the parent of a node with a depth.
 pub fn parent_with_depth(i: u64, depth: u64) -> u64 {
-  return index(depth + 1, offset_with_depth(i, depth) >> 1);
+  index(depth + 1, offset_with_depth(i, depth) >> 1)
 }
 
 /// Returns the parent of a node.
@@ -85,12 +89,12 @@ pub fn parent_with_depth(i: u64, depth: u64) -> u64 {
 /// assert_eq!(flat_tree::parent(1), 3);
 /// ```
 pub fn parent(i: u64) -> u64 {
-  return parent_with_depth(i, depth(i));
+  parent_with_depth(i, depth(i))
 }
 
 /// Returns the sibling of a node with a depth.
 pub fn sibling_with_depth(i: u64, depth: u64) -> u64 {
-  return index(depth, offset(i) ^ 1);
+  index(depth, offset(i) ^ 1)
 }
 
 /// Returns the sibling of a node.
@@ -103,87 +107,98 @@ pub fn sibling_with_depth(i: u64, depth: u64) -> u64 {
 /// assert_eq!(flat_tree::sibling(5), 1);
 /// ```
 pub fn sibling(i: u64) -> u64 {
-  return sibling_with_depth(i, depth(i));
+  sibling_with_depth(i, depth(i))
 }
 
 /// Returns the parent's sibling, of a node, with a depth.
 pub fn uncle_with_depth(i: u64, depth: u64) -> u64 {
-  return sibling_with_depth(parent_with_depth(i, depth), depth + 1);
+  sibling_with_depth(parent_with_depth(i, depth), depth + 1)
 }
 
 /// Returns the parent's sibling, of a node.
 pub fn uncle(i: u64) -> u64 {
-  return uncle_with_depth(i, depth(i));
+  uncle_with_depth(i, depth(i))
 }
 
 /// Returns both children of a node, with a depth.
-pub fn children_with_depth(i: u64, depth: u64) -> (u64, u64) {
-  if depth == 0 {
-    return (i, i);
+pub fn children_with_depth(i: u64, depth: u64) -> Option<(u64, u64)> {
+  if is_even(i) {
+    None
+  } else if depth == 0 {
+    Some((i, i))
+  } else {
+    let off = offset_with_depth(i, depth) >> 1;
+    Some((index(depth - 1, off), index(depth - 1, off + 1)))
   }
-
-  let off = offset_with_depth(i, depth) >> 1;
-  return (index(depth - 1, off), index(depth - 1, off + 1));
 }
 
 /// Returns both children of a node.
 ///
 /// ## Examples
 /// ```rust
-/// assert_eq!(flat_tree::children(0), (0, 0));
-/// assert_eq!(flat_tree::children(1), (0, 2));
-/// assert_eq!(flat_tree::children(3), (1, 5));
+/// assert_eq!(flat_tree::children(0), None);
+/// assert_eq!(flat_tree::children(1), Some((0, 2)));
+/// assert_eq!(flat_tree::children(3), Some((1, 5)));
 /// ```
-pub fn children(i: u64) -> (u64, u64) {
-  return children_with_depth(i, depth(i));
+pub fn children(i: u64) -> Option<(u64, u64)> {
+  children_with_depth(i, depth(i))
 }
 
 /// Returns only the left child of a node, with a depth
-pub fn left_child_with_depth(i: u64, depth: u64) -> u64 {
-  if depth == 0 {
-    return i;
+// TODO: handle errors
+pub fn left_child_with_depth(i: u64, depth: u64) -> Option<u64> {
+  if is_even(i) {
+    None
+  } else if depth == 0 {
+    Some(i)
+  } else {
+    Some(index(depth - 1, offset_with_depth(i, depth) << 1))
   }
-  return index(depth - 1, offset_with_depth(i, depth) << 1);
 }
 
 /// Returns only the left child of a node.
 ///
 /// ## Examples
 /// ```rust
-/// assert_eq!(flat_tree::left_child(0), 0);
-/// assert_eq!(flat_tree::left_child(1), 0);
-/// assert_eq!(flat_tree::left_child(3), 1);
+/// assert_eq!(flat_tree::left_child(0), None);
+/// assert_eq!(flat_tree::left_child(1), Some(0));
+/// assert_eq!(flat_tree::left_child(3), Some(1));
 /// ```
-pub fn left_child(i: u64) -> u64 {
-  return left_child_with_depth(i, depth(i));
+pub fn left_child(i: u64) -> Option<u64> {
+  left_child_with_depth(i, depth(i))
 }
 
 /// Returns only the left child of a node, with a depth.
-pub fn right_child_with_depth(i: u64, depth: u64) -> u64 {
-  if depth == 0 {
-    return i;
+pub fn right_child_with_depth(i: u64, depth: u64) -> Option<u64> {
+  if is_even(i) {
+    None
+  } else if depth == 0 {
+    Some(i)
+  } else {
+    Some(index(depth - 1, (offset_with_depth(i, depth) << 1) + 1))
   }
-  return index(depth - 1, (offset_with_depth(i, depth) << 1) + 1);
 }
 
 /// Returns only the left child of a node.
 ///
 /// ## Examples
 /// ```rust
-/// assert_eq!(flat_tree::right_child(0), 0);
-/// assert_eq!(flat_tree::right_child(1), 2);
-/// assert_eq!(flat_tree::right_child(3), 5);
+/// assert_eq!(flat_tree::right_child(0), None);
+/// assert_eq!(flat_tree::right_child(1), Some(2));
+/// assert_eq!(flat_tree::right_child(3), Some(5));
 /// ```
-pub fn right_child(i: u64) -> u64 {
-  return right_child_with_depth(i, depth(i));
+// TODO: handle errors
+pub fn right_child(i: u64) -> Option<u64> {
+  right_child_with_depth(i, depth(i))
 }
 
 /// Returns the right most node in the tree that the node spans, with a depth.
 pub fn right_span_with_depth(i: u64, depth: u64) -> u64 {
   if depth == 0 {
-    return i;
+    i
+  } else {
+    (offset_with_depth(i, depth) + 1) * (2 << depth) - 2
   }
-  return (offset_with_depth(i, depth) + 1) * (2 << depth) - 2;
 }
 
 /// Returns the right most node in the tree that the node spans.
@@ -197,15 +212,16 @@ pub fn right_span_with_depth(i: u64, depth: u64) -> u64 {
 /// assert_eq!(flat_tree::right_span(27), 30);
 /// ```
 pub fn right_span(i: u64) -> u64 {
-  return right_span_with_depth(i, depth(i));
+  right_span_with_depth(i, depth(i))
 }
 
 /// Returns the left most node in the tree that the node spans, with a depth.
 pub fn left_span_with_depth(i: u64, depth: u64) -> u64 {
   if depth == 0 {
-    return i;
+    i
+  } else {
+    offset_with_depth(i, depth) * (2 << depth)
   }
-  return offset_with_depth(i, depth) * (2 << depth);
 }
 
 /// Returns the left most node in the tree that it spans.
@@ -219,16 +235,16 @@ pub fn left_span_with_depth(i: u64, depth: u64) -> u64 {
 /// assert_eq!(flat_tree::left_span(27), 24);
 /// ```
 pub fn left_span(i: u64) -> u64 {
-  return left_span_with_depth(i, depth(i));
+  left_span_with_depth(i, depth(i))
 }
 
 /// Returns the left and right most nodes in the tree that the node spans, with
 /// a depth.
 pub fn spans_with_depth(i: u64, depth: u64) -> (u64, u64) {
-  return (
+  (
     left_span_with_depth(i, depth),
     right_span_with_depth(i, depth),
-  );
+  )
 }
 
 /// Returns the left and right most nodes in the tree that the node spans.
@@ -242,12 +258,12 @@ pub fn spans_with_depth(i: u64, depth: u64) -> (u64, u64) {
 /// assert_eq!(flat_tree::spans(27), (24, 30));
 /// ```
 pub fn spans(i: u64) -> (u64, u64) {
-  return spans_with_depth(i, depth(i));
+  spans_with_depth(i, depth(i))
 }
 
 /// Returns how many nodes are in the tree that the node spans, with a depth.
 pub fn count_with_depth(_: u64, depth: u64) -> u64 {
-  return (2 << depth) - 1;
+  (2 << depth) - 1
 }
 
 /// Returns how many nodes are in the tree that the node spans.
@@ -262,7 +278,7 @@ pub fn count_with_depth(_: u64, depth: u64) -> u64 {
 /// assert_eq!(flat_tree::count(27), 7);
 /// ```
 pub fn count(i: u64) -> u64 {
-  return count_with_depth(i, depth(i));
+  count_with_depth(i, depth(i))
 }
 
 /// Returns all the previous fully rooted trees before the node.
@@ -279,31 +295,57 @@ pub fn count(i: u64) -> u64 {
 pub fn full_roots(i: u64) -> Vec<u64> {
   let mut result = Vec::with_capacity(64);
 
-  if i & 1 != 0 {
-    return result;
-  }
+  if is_odd(i) {
+    result
+  } else {
+    let mut tmp = i >> 1;
+    let mut offset = 0;
+    let mut factor = 1;
 
-  let mut tmp = i >> 1;
-  let mut offset = 0;
-  let mut factor = 1;
+    loop {
+      if tmp == 0 {
+        break;
+      }
+      while factor * 2 <= tmp {
+        factor *= 2;
+      }
+      result.push(offset + factor - 1);
+      offset += 2 * factor;
+      tmp -= factor;
+      factor = 1;
+    }
 
-  loop {
-    if tmp == 0 {
-      return result;
-    }
-    while factor * 2 <= tmp {
-      factor *= 2;
-    }
-    result.push(offset + factor - 1);
-    offset += 2 * factor;
-    tmp -= factor;
-    factor = 1;
+    result
   }
+}
+
+#[inline(always)]
+fn is_even(num: u64) -> bool {
+  (num & 1) == 0
+}
+#[test]
+fn test_is_even() {
+  assert_eq!(is_even(0), true);
+  assert_eq!(is_even(1), false);
+  assert_eq!(is_even(2), true);
+  assert_eq!(is_even(3), false);
+}
+
+#[inline(always)]
+fn is_odd(num: u64) -> bool {
+  (num & 1) != 0
+}
+#[test]
+fn test_is_odd() {
+  assert_eq!(is_odd(0), false);
+  assert_eq!(is_odd(1), true);
+  assert_eq!(is_odd(2), false);
+  assert_eq!(is_odd(3), true);
 }
 
 #[test]
 fn test_parent_gt_int32() {
-  assert_eq!(parent(10000000000), 10000000001);
+  assert_eq!(parent(10_000_000_000), 10_000_000_001);
 }
 
 #[test]
@@ -314,7 +356,7 @@ fn test_child_to_parent_to_child() {
   }
   assert_eq!(child, 1125899906842623);
   for _ in 0..50 {
-    child = left_child(child)
+    child = left_child(child).expect("no valid number returned");
   }
   assert_eq!(child, 0);
 }


### PR DESCRIPTION
We weren't handling the case where there aren't any children / `null` was returned. By using an `Option` type, we can handle this case.

PR is a bit noisy, did some of the things [Clippy](https://github.com/rust-lang-nursery/rust-clippy) suggested we change (e.g. use of `return` keyword).

Hope this mostly makes sense! Thanks!